### PR TITLE
Feature/user profile page/story 19 and 20

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -34,11 +34,10 @@ class SessionsController < ApplicationController
     end
   end
 
-
   def destroy
     session.delete(:user_id)
     session.delete(:cart)
-    flash[:notice] = "Goodbye, you are now logged out."
+    flash[:success] = "Goodbye, you are now logged out."
     redirect_to '/'
   end
 
@@ -63,5 +62,4 @@ class SessionsController < ApplicationController
       session[:user_id] = user.id
       flash[:success] = "Welcome back, #{user.name} you are now logged in!"
     end
-
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -25,20 +25,34 @@ class UsersController < ApplicationController
   end
 
   def update
-    user = current_user
+    # user = current_user
 
-    if user.update(user_params)
-      flash[:success] = "Your information has been updated."
-      redirect_to profile_path
+    if current_user.authenticate(params[:password])
+      attempt_update(current_user)
     else
-      flash[:notice] = user.errors.full_messages.to_sentence + ". Please fill out all required fields."
-      @user = current_user
-      render :edit
+      incorrect_password
     end
   end
 
   private
     def user_params
       params.permit(:name, :address, :city, :state, :zip, :email, :password, :password_confirmation)
+    end
+
+    def attempt_update(user)
+      if user.update(user_params)
+        flash[:success] = "Your information has been updated."
+        redirect_to profile_path
+      else
+        flash.now[:error] = user.errors.full_messages.to_sentence + ". Please fill out all required fields."
+        @user = current_user
+        render :edit
+      end
+    end
+
+    def incorrect_password
+      flash.now[:error] = "Password is incorrect. Please try again."
+      @user = current_user
+      render :edit
     end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -26,9 +26,7 @@ class UsersController < ApplicationController
 
   def update
     user = current_user
-    #require "pry"; binding.pry
-    # user.update_attributes(update_user_params)
-    require "pry"; binding.pry
+
     if user.update(user_params)
       flash[:success] = "Your information has been updated."
       redirect_to profile_path
@@ -42,9 +40,5 @@ class UsersController < ApplicationController
   private
     def user_params
       params.permit(:name, :address, :city, :state, :zip, :email, :password, :password_confirmation)
-    end
-
-    def update_user_params
-      params.permit(:name, :address, :city, :state, :zip, :email)
     end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -26,7 +26,9 @@ class UsersController < ApplicationController
 
   def update
     user = current_user
-
+    #require "pry"; binding.pry
+    # user.update_attributes(update_user_params)
+    require "pry"; binding.pry
     if user.update(user_params)
       flash[:success] = "Your information has been updated."
       redirect_to profile_path
@@ -40,5 +42,9 @@ class UsersController < ApplicationController
   private
     def user_params
       params.permit(:name, :address, :city, :state, :zip, :email, :password, :password_confirmation)
+    end
+
+    def update_user_params
+      params.permit(:name, :address, :city, :state, :zip, :email)
     end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -20,6 +20,23 @@ class UsersController < ApplicationController
     end
   end
 
+  def edit
+    @user = current_user
+  end
+
+  def update
+    user = current_user
+
+    if user.update(user_params)
+      flash[:success] = "Your information has been updated."
+      redirect_to profile_path
+    else
+      flash[:notice] = user.errors.full_messages.to_sentence + ". Please fill out all required fields."
+      @user = current_user
+      render :edit
+    end
+  end
+
   private
     def user_params
       params.permit(:name, :address, :city, :state, :zip, :email, :password, :password_confirmation)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,6 @@
 class User < ApplicationRecord
   validates :email, uniqueness: true, presence: true
-  validates_presence_of :password, require: true, on: :create
+  validates_presence_of :password, require: true
 
   validates_presence_of :name, :address, :city, :state, :zip
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,6 @@
 class User < ApplicationRecord
   validates :email, uniqueness: true, presence: true
-  validates_presence_of :password, require: true
+  validates_presence_of :password, require: true, on: :create
 
   validates_presence_of :name, :address, :city, :state, :zip
 

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -1,0 +1,21 @@
+<%= form_tag path, method: method do %>
+  <%= label_tag :name %>
+  <%= text_field_tag :name, user_name %>
+  <%= label_tag :address %>
+  <%= text_field_tag :address, user_address %>
+  <%= label_tag :city %>
+  <%= text_field_tag :city, user_city %>
+  <%= label_tag :state %>
+  <%= text_field_tag :state, user_state %>
+  <%= label_tag :zip %>
+  <%= text_field_tag :zip, user_zip %>
+  <%= label_tag :email %>
+  <%= text_field_tag :email, user_email %>
+
+  <%# <%= label_tag :password %> %>
+  <%# <%= password_field_tag :password %> %>
+  <%# <%= label_tag :password_confirmation %> %>
+  <%# <%= password_field_tag :password_confirmation %> %>
+
+  <%= submit_tag button_text %>
+<% end %>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -12,8 +12,8 @@
   <%= label_tag :email %>
   <%= text_field_tag :email, user_email %>
 
-  <%= label_tag :password %>
-  <%= password_field_tag :password %>
+  <%# <%= label_tag :password %> %>
+  <%# <%= password_field_tag :password %> %>
 
   <%# <%= label_tag :password_confirmation %> %>
   <%# <%= password_field_tag :password_confirmation %> %>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -12,8 +12,9 @@
   <%= label_tag :email %>
   <%= text_field_tag :email, user_email %>
 
-  <%# <%= label_tag :password %> %>
-  <%# <%= password_field_tag :password %> %>
+  <%= label_tag :password %>
+  <%= password_field_tag :password %>
+
   <%# <%= label_tag :password_confirmation %> %>
   <%# <%= password_field_tag :password_confirmation %> %>
 

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -12,8 +12,8 @@
   <%= label_tag :email %>
   <%= text_field_tag :email, user_email %>
 
-  <%# <%= label_tag :password %> %>
-  <%# <%= password_field_tag :password %> %>
+  <%= label_tag :password %>
+  <%= password_field_tag :password %>
 
   <%# <%= label_tag :password_confirmation %> %>
   <%# <%= password_field_tag :password_confirmation %> %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,0 +1,12 @@
+<h1>Edit Profile Information For <%= @user.name %> </h1>
+<%= render partial: 'form', locals: {
+    path: profile_path,
+    method: :patch,
+    button_text: 'Submit',
+    user_name: @user.name,
+    user_address: @user.address,
+    user_city: @user.city,
+    user_state: @user.state,
+    user_zip: @user.zip,
+    user_email: @user.email
+} %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -7,4 +7,4 @@
 <p><b>Zip:</b> <%= @user.zip %> </p>
 <p><b>Email:</b> <%= @user.email %> </p>
 
-<%= link_to 'Edit My Info' %>
+<%= link_to 'Edit My Info', profile_edit_path %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,1 +1,10 @@
 <h1>Hello, <%= @user.name %>!</h1>
+
+<p><b>Name:</b> <%= @user.name %> </p>
+<p><b>Address:</b> <%= @user.address %> </p>
+<p><b>City:</b> <%= @user.city %> </p>
+<p><b>State:</b> <%= @user.state %> </p>
+<p><b>Zip:</b> <%= @user.zip %> </p>
+<p><b>Email:</b> <%= @user.email %> </p>
+
+<%= link_to 'Edit My Info' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,8 @@ Rails.application.routes.draw do
   get "/users/register", to: "users#new"
   post "/users", to: "users#create"
   get "/profile", to: "users#show"
+  get "/profile/edit", to: "users#edit"
+  patch "/profile", to: "users#update"
 
   get '/login', to: 'sessions#new'
   post '/login', to: 'sessions#create'

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     sequence(:city) { |n| "Den #{n}" }
     sequence(:state) { |n| "CO #{n}" }
     sequence(:zip) { |n| "8012#{n}" }
-    sequence(:email) { |n| "johndoe#{n}@gmail.com " }
+    sequence(:email) { |n| "johndoe#{n}@gmail.com" }
     password {"password"}
     password_confirmation {"password"}
     role {0}

--- a/spec/features/users/edit_spec.rb
+++ b/spec/features/users/edit_spec.rb
@@ -5,21 +5,21 @@ RSpec.describe "As a registered user" do
     before :each do
       @user = create(:user, role: 0)
 
+      @original_address = "1 Lane"
+      @original_city = "Den 1"
+      @original_state = "CO 1"
+
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
     end
 
     it "by filling out a form with my changes" do
 
-      original_address = "1 Lane"
-      original_city = "Den 1"
-      original_state = "CO 1"
-
       visit '/profile'
 
       expect(page).to have_content("Name: #{@user.name}")
-      expect(page).to have_content("Address: #{original_address}")
-      expect(page).to have_content("City: #{original_city}")
-      expect(page).to have_content("State: #{original_state}")
+      expect(page).to have_content("Address: #{@original_address}")
+      expect(page).to have_content("City: #{@original_city}")
+      expect(page).to have_content("State: #{@original_state}")
       expect(page).to have_content("Zip: #{@user.zip}")
       expect(page).to have_content("Email: #{@user.email}")
 
@@ -33,6 +33,7 @@ RSpec.describe "As a registered user" do
       expect(find_field('State').value).to eq(@user.state)
       expect(find_field('Zip').value).to eq(@user.zip.to_s)
       expect(find_field('Email').value).to eq(@user.email)
+      expect(find_field('Password').value).to eq(nil)
 
       new_address = "456 South St"
       new_city = "Boulder"
@@ -41,6 +42,7 @@ RSpec.describe "As a registered user" do
       fill_in :address, with: new_address
       fill_in :city, with: new_city
       fill_in :state, with: new_state
+      fill_in :password, with: "password"
 
       click_button 'Submit'
 
@@ -55,9 +57,30 @@ RSpec.describe "As a registered user" do
       expect(page).to have_content("Zip: #{@user.zip.to_s}")
       expect(page).to have_content("Email: #{@user.email}")
 
-      expect(page).to_not have_content(original_address)
-      expect(page).to_not have_content(original_city)
-      expect(page).to_not have_content(original_state)
+      expect(page).to_not have_content(@original_address)
+      expect(page).to_not have_content(@original_city)
+      expect(page).to_not have_content(@original_state)
+    end
+
+    it "displays an error message if I fail to enter the correct password" do
+      visit '/profile'
+
+      click_link 'Edit My Info'
+
+      new_address = "456 South St"
+      new_city = "Boulder"
+      new_state = "AZ"
+
+      fill_in :address, with: new_address
+      fill_in :city, with: new_city
+      fill_in :state, with: new_state
+      fill_in :password, with: "notmypassword"
+
+      click_button('Submit')
+
+      expect(page).to have_button('Submit')
+
+      expect(page).to have_content("Password is incorrect. Please try again.")
     end
 
     it "displays an error message if I fail to fill out all fields" do
@@ -67,6 +90,7 @@ RSpec.describe "As a registered user" do
       click_link 'Edit My Info'
 
       fill_in :address, with: nil
+      fill_in :password, with: "password"
 
       click_button 'Submit'
 

--- a/spec/features/users/edit_spec.rb
+++ b/spec/features/users/edit_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.describe "As a registered user" do
+  describe "I can edit my information" do
+    it "by filling out a form with my changes" do
+      user = create(:user, role: 0)
+
+      original_address = "1 Lane"
+      original_city = "Den 1"
+      original_state = "CO 1"
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+      visit '/profile'
+
+      expect(page).to have_content("Name: #{user.name}")
+      expect(page).to have_content("Address: #{original_address}")
+      expect(page).to have_content("City: #{original_city}")
+      expect(page).to have_content("State: #{original_state}")
+      expect(page).to have_content("Zip: #{user.zip}")
+      expect(page).to have_content("Email: #{user.email}")
+
+      click_link 'Edit My Info'
+
+      expect(current_path).to eq('/profile/edit')
+
+      expect(find_field('Name').value).to eq(user.name)
+      expect(find_field('Address').value).to eq(user.address)
+      expect(find_field('City').value).to eq(user.city)
+      expect(find_field('State').value).to eq(user.state)
+      expect(find_field('Zip').value).to eq(user.zip)
+      expect(find_field('Email').value).to eq(user.email)
+      
+      new_address = "456 South St"
+      new_city = "Boulder"
+      new_state = "AZ"
+
+      fill_in :address, with: new_address
+      fill_in :city, with: new_city
+      fill_in :state, with: new_state
+
+      click_button 'Submit'
+
+      expect(current_path).to eq(profile_path)
+
+      expect(page).to have_content("Your information has been updated.")
+
+      expect(page).to have_content("Name: #{user.name}")
+      expect(page).to have_content("Address: #{new_address}")
+      expect(page).to have_content("City: #{new_city}")
+      expect(page).to have_content("State: #{new_state}")
+      expect(page).to have_content("Zip: #{user.zip}")
+      expect(page).to have_content("Email: #{user.email}")
+
+      expect(page).to_not have_content(original_address)
+      expect(page).to_not have_content(original_city)
+      expect(page).to_not have_content(original_state)
+    end
+  end
+end

--- a/spec/features/users/edit_spec.rb
+++ b/spec/features/users/edit_spec.rb
@@ -2,35 +2,41 @@ require 'rails_helper'
 
 RSpec.describe "As a registered user" do
   describe "I can edit my information" do
-    it "by filling out a form with my changes" do
-      user = create(:user, role: 0)
+    before :each do
+      @user = create(:user, role: 0)
 
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
+
+    end
+
+    it "by filling out a form with my changes" do
+      # user = create(:user, role: 0)
       original_address = "1 Lane"
       original_city = "Den 1"
       original_state = "CO 1"
 
-      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+      # allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 
       visit '/profile'
 
-      expect(page).to have_content("Name: #{user.name}")
+      expect(page).to have_content("Name: #{@user.name}")
       expect(page).to have_content("Address: #{original_address}")
       expect(page).to have_content("City: #{original_city}")
       expect(page).to have_content("State: #{original_state}")
-      expect(page).to have_content("Zip: #{user.zip}")
-      expect(page).to have_content("Email: #{user.email}")
+      expect(page).to have_content("Zip: #{@user.zip}")
+      expect(page).to have_content("Email: #{@user.email}")
 
       click_link 'Edit My Info'
 
       expect(current_path).to eq('/profile/edit')
 
-      expect(find_field('Name').value).to eq(user.name)
-      expect(find_field('Address').value).to eq(user.address)
-      expect(find_field('City').value).to eq(user.city)
-      expect(find_field('State').value).to eq(user.state)
-      expect(find_field('Zip').value).to eq(user.zip)
-      expect(find_field('Email').value).to eq(user.email)
-      
+      expect(find_field('Name').value).to eq(@user.name)
+      expect(find_field('Address').value).to eq(@user.address)
+      expect(find_field('City').value).to eq(@user.city)
+      expect(find_field('State').value).to eq(@user.state)
+      expect(find_field('Zip').value).to eq(@user.zip.to_s)
+      expect(find_field('Email').value).to eq(@user.email)
+
       new_address = "456 South St"
       new_city = "Boulder"
       new_state = "AZ"
@@ -45,16 +51,31 @@ RSpec.describe "As a registered user" do
 
       expect(page).to have_content("Your information has been updated.")
 
-      expect(page).to have_content("Name: #{user.name}")
+      expect(page).to have_content("Name: #{@user.name}")
       expect(page).to have_content("Address: #{new_address}")
       expect(page).to have_content("City: #{new_city}")
       expect(page).to have_content("State: #{new_state}")
-      expect(page).to have_content("Zip: #{user.zip}")
-      expect(page).to have_content("Email: #{user.email}")
+      expect(page).to have_content("Zip: #{@user.zip.to_s}")
+      expect(page).to have_content("Email: #{@user.email}")
 
       expect(page).to_not have_content(original_address)
       expect(page).to_not have_content(original_city)
       expect(page).to_not have_content(original_state)
+    end
+
+    it "displays an error message if I fail to fill out all fields" do
+
+      visit '/profile'
+
+      click_link 'Edit My Info'
+
+      fill_in :address, with: nil
+
+      click_button 'Submit'
+
+      expect(page).to have_button('Submit')
+
+      expect(page).to have_content("Address can't be blank. Please fill out all required fields.")
     end
   end
 end

--- a/spec/features/users/edit_spec.rb
+++ b/spec/features/users/edit_spec.rb
@@ -6,16 +6,13 @@ RSpec.describe "As a registered user" do
       @user = create(:user, role: 0)
 
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
-
     end
 
     it "by filling out a form with my changes" do
-      # user = create(:user, role: 0)
+
       original_address = "1 Lane"
       original_city = "Den 1"
       original_state = "CO 1"
-
-      # allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 
       visit '/profile'
 

--- a/spec/features/users/show_spec.rb
+++ b/spec/features/users/show_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe "As a user" do
+  describe "on my profile page" do
+    it "I see all my info except my password and a link to edit my info" do
+      user = create(:user, role: 0)
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+      visit(profile_path)
+
+      expect(page).to have_content("Name: #{user.name}")
+      expect(page).to have_content("Address: #{user.address}")
+      expect(page).to have_content("City: #{user.city}")
+      expect(page).to have_content("State: #{user.state}")
+      expect(page).to have_content("Zip: #{user.zip}")
+      # expect(page).to have_content(user.email)
+      expect(page).to have_content("Email: #{user.email}")
+      expect(page).to_not have_content(user.password)
+
+      click_on 'Edit My Info'
+    end
+  end
+end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -48,7 +48,7 @@ describe Merchant, type: :model do
       order_2.item_orders.create!(item: chain, price: chain.price, quantity: 2)
       order_3.item_orders.create!(item: @tire, price: @tire.price, quantity: 2)
 
-      expect(@meg.distinct_cities).to eq(["Denver","Hershey"])
+      expect(@meg.distinct_cities).to match_array(["Hershey", "Denver"])
     end
 
   end


### PR DESCRIPTION
**Functionality:**
- This branch encompasses the ability for a user to view their information on their profile page (user show page) (story 19) and to edit that information (story 20).
- A change was made to the user model to only require a password on the create action. You can see this in the file. I am not sure if this will need to be changed later, so pointing it out here. **UPDATE:** This change was revoked, as the password field is required on the edit form. 
**UPDATE:** The edit form now has the password box and the user must be authenticated before `user.update(user_params)` will run. 

**Testing:**
- All tests are passing in rspec(100%) and working in local development.

**Related Issues:**
#16 
#19 
- Notes: I did make a partial thinking we could use that for both the new and edit views for users, but we might not be able to. 
- As of now, the edit form does NOT include a field for password at all. Asked Meg and Mike about it and waiting for clarification about if that should be shown on the page or not. 
- **UPDATE:** The edit form DOES need a password field, this has been accounted for in the most recent commits.