### PR TITLE
Feature/merchant crud/story 44

### DIFF
--- a/app/controllers/merchant/items_controller.rb
+++ b/app/controllers/merchant/items_controller.rb
@@ -14,6 +14,14 @@ class Merchant::ItemsController < Merchant::BaseController
     elsif activate?
       activate(item)
     end
+
+    redirect_to merchant_items_path
+  end
+
+  def destroy
+    item = Item.find(params[:id])
+    item.destroy
+    flash[:success] = "#{item.name} has been deleted."
     
     redirect_to merchant_items_path
   end

--- a/app/views/merchant/items/index.html.erb
+++ b/app/views/merchant/items/index.html.erb
@@ -9,6 +9,7 @@
         <p> <%= item.description %> </p>
         <p>Price: <%=number_to_currency(item.price) %> </p>
         <p>Inventory: <%= item.inventory %> </p>
+        
       <% if item.active? %>
         <p>Status: Active</p>
         <%= button_to 'Deactivate', "/merchant/items/#{item.id}?status=deactivate", method: :patch %>
@@ -16,7 +17,7 @@
         <p>Status: Inactive</p>
         <%= button_to 'Activate', "/merchant/items/#{item.id}?status=activate", method: :patch %>
       <% end %>
-      <%# <%= link_to_if(item.never_ordered?, "Delete", "/merchant/items/#{item.id}", method: :delete) %> %>
+
       <% if item.no_orders? %>
         <%= button_to 'Delete', "/merchant/items/#{item.id}", method: :delete %>
       <% end %>

--- a/app/views/merchant/items/index.html.erb
+++ b/app/views/merchant/items/index.html.erb
@@ -16,6 +16,10 @@
         <p>Status: Inactive</p>
         <%= button_to 'Activate', "/merchant/items/#{item.id}?status=activate", method: :patch %>
       <% end %>
+      <%# <%= link_to_if(item.never_ordered?, "Delete", "/merchant/items/#{item.id}", method: :delete) %> %>
+      <% if item.no_orders? %>
+        <%= button_to 'Delete', "/merchant/items/#{item.id}", method: :delete %>
+      <% end %>
     </section>
   <% end %>
 </section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,7 +56,7 @@ Rails.application.routes.draw do
   namespace :merchant  do
     get '/', to: 'dashboard#show'
     resources :orders, only: [:show, :update]
-    resources :items, only: [:index, :show, :update]
+    resources :items, only: [:index, :show, :update, :destroy]
   end
 
   namespace :admin do

--- a/spec/features/merchant/merchant_items_spec.rb
+++ b/spec/features/merchant/merchant_items_spec.rb
@@ -118,5 +118,37 @@ RSpec.describe "As a merchant" do
         expect(page).to_not have_button("Activate")
       end
     end
+
+    it "I can delete an item that has never been ordered by clicking its delete button" do
+      visit merchant_items_path
+
+      within "#item-#{@item_1.id}" do
+        expect(page).to have_button("Delete")
+      end
+
+      within "#item-#{@item_2.id}" do
+        expect(page).to have_button("Delete")
+      end
+
+      within "#item-#{@item_3.id}" do
+        click_button "Delete"
+      end
+
+      expect(current_path).to eq(merchant_items_path)
+      expect(page).to have_content("#{@item_3.name} has been deleted.")
+
+      expect(page).to_not have_css("#item-#{@item_3.id}")
+    end
+
+    it "There is not a delete button for an item that has been ordered" do
+      order = create(:order)
+      order.item_orders.create(item: @item_1, quantity: 2, price: @item_1.price)
+
+      visit merchant_items_path
+      
+      within "#item-#{@item_1.id}" do
+        expect(page).to_not have_button("Delete")
+      end
+    end
   end
 end

--- a/spec/features/merchant/merchant_items_spec.rb
+++ b/spec/features/merchant/merchant_items_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "As a merchant" do
       @merchant = create(:merchant)
       @item_1 = create(:item, merchant: @merchant)
       @item_2 = create(:item, merchant: @merchant)
-      @item_3 = create(:item, merchant: @merchant, active?: false)
+      @item_3 = create(:item, description: "Item 3 description", merchant: @merchant, active?: false, image: "https://cdn.shopify.com/s/files/1/0836/6919/products/thousand-helmet-rose-gold-1_2000x.jpg?v=1568244140")
 
       @merchant_employee = create(:user, role: 1, merchant: @merchant)
 
@@ -138,15 +138,34 @@ RSpec.describe "As a merchant" do
       expect(page).to have_content("#{@item_3.name} has been deleted.")
 
       expect(page).to_not have_css("#item-#{@item_3.id}")
+      expect(page).to_not have_link(@item_3.name)
+      expect(page).to_not have_content(@item_3.description)
+      expect(page).to_not have_content("Price: $#{@item_3.price}")
+      expect(page).to_not have_content("Inventory: #{@item_3.inventory}")
+      expect(page).to_not have_css("img[src*='#{@item_3.image}']")
     end
 
-    it "There is not a delete button for an item that has been ordered" do
-      order = create(:order)
-      order.item_orders.create(item: @item_1, quantity: 2, price: @item_1.price)
+    it "There is not a delete button for an item that has been ordered, regardles of order status" do
+      order_1 = create(:order)
+      order_1.item_orders.create(item: @item_1, quantity: 2, price: @item_1.price)
+
+      order_2 = create(:order, status: 1)
+      order_2.item_orders.create(item: @item_2, quantity: 2, price: @item_2.price)
+
+      order_3 = create(:order, status: 3)
+      order_3.item_orders.create(item: @item_3, quantity: 2, price: @item_3.price)
 
       visit merchant_items_path
-      
+
       within "#item-#{@item_1.id}" do
+        expect(page).to_not have_button("Delete")
+      end
+
+      within "#item-#{@item_2.id}" do
+        expect(page).to_not have_button("Delete")
+      end
+
+      within "#item-#{@item_3.id}" do
         expect(page).to_not have_button("Delete")
       end
     end


### PR DESCRIPTION
**Functionality:**
* Story 44 add functionality for a merchant employee to be able to delete an item (that has never been ordered) from their merchant index page.
* Utilized an existing item model method `no_orders?` to add a delete button to only items with no orders.
* This deletes the item from the database completely.

**Testing:**
* Testing ensures that orders of any status (even canceled) prevent the delete button from displaying.
* RSPEC at 100% and functioning in devo.

**Related Issues:**
#84 
